### PR TITLE
added 3.6 and 3.2 support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -280,16 +280,13 @@ FirefoxBookmarksSearchProvider.prototype = {
     },
 
     getInitialResultSet: function(terms) {
-        log('getInitialResultSet');
         // check if a found host-name begins like the search-term
-        let searchResults = [];
-        searchResults = searchResults.concat(this._checkBookmarknames(this._configBookmarks, terms));
-
-        if (searchResults.length > 0) {
-            return(searchResults);
+        let results = this._checkBookmarknames(this._configBookmarks, terms);
+        // 3.6 compatibility
+        if (ShellVersion[1] >= 6) {
+            this.searchSystem.pushResults(this, results);
         }
-
-        return []
+        return results;
     },
 
     getSubsearchResultSet: function(previousResults, terms) {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
-    "shell-version": ["3.3.90", "3.3.91", "3.3.92","3.4"],
-    "version": "0.3",
+    "shell-version": ["3.2", "3.4", "3.6"],
+    "version": "0.4",
     "uuid": "searchfirefoxbookmarks@ciancio.net",
     "name": "Search Firefox Bookmarks Provider",
     "description": "A gnome-shell extension which searches the firefox bookmarks and provides results in your shell overview.",


### PR DESCRIPTION
Hi,

I modified the code to get it working on 3.2, 3.4, and 3.6 with the one version.

I also made some other changes (which you may or may not like) like
- running through jshint
- make the bookmarkFileMonitor variable local to the class (since it's not really a public variable)
- modified the search algorithm because before if a bookmark matched (say) 2 of the search terms, it would turn up twice in the results. Now it only turns up once.

If you don't like these, the bare minimum specific changes to get it working with 3.6 are:
- in getInitialResultSet and getSubsearchResultSet for 3.6 instead of returning the resutls you do
  
  ```
  this.searchSystem.pushResults(results);
  ```
- in getResultMetas there's an additional parameter `callback` and you're meant to apply it to the search results.
