### PR TITLE
Call function of the new api

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -356,15 +356,23 @@ function init() {
 function enable() {
     if (!FBSearchProvider) {
         FBSearchProvider = new FirefoxBookmarksSearchProvider("FIREFOX BOOKMARKS");
-        Main.overview.viewSelector._searchResults._searchSystem.addProvider(FBSearchProvider);
+        if(typeof Main.overview.viewSelector._searchResults._registerProvider === "function") { //3.14
+            Main.overview.viewSelector._searchResults._registerProvider(FBSearchProvider);
+        } else if(typeof Main.overview.viewSelector._searchResults._searchSystem === "object" &&
+                  typeof Main.overview.viewSelector._searchResults._searchSystem.addProvider === "function") { //3.12
+            Main.overview.viewSelector._searchResults._searchSystem.addProvider(FBSearchProvider);
+        }
     }
 }
 
 function disable() {
     if (FBSearchProvider) {
-        // Main.overview.removeSearchProvider(FBSearchProvider);
-        Main.overview.viewSelector._searchResults._searchSystem._unregisterProvider(FBSearchProvider);
-        Main.overview.viewSelector._searchResults._searchSystem.emit('providers-changed');
+        if(typeof Main.overview.viewSelector._searchResults._registerProvider === "function") { //3.14
+            Main.overview.viewSelector._searchResults._unregisterProvider(FBSearchProvider);
+        } else {
+            Main.overview.viewSelector._searchResults._searchSystem._unregisterProvider(FBSearchProvider);
+            Main.overview.viewSelector._searchResults._searchSystem.emit('providers-changed');
+        }
         FBSearchProvider.destroy();
         FBSearchProvider = null;
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
-    "shell-version": ["3.12"],
-    "version": "0.4.3",
+    "shell-version": ["3.12", "3.18"],
+    "version": "0.4.4",
     "uuid": "searchfirefoxbookmarks@ciancio.net",
     "name": "Search Firefox Bookmarks Provider",
     "description": "A gnome-shell extension which searches the firefox bookmarks and provides results in your shell overview.",


### PR DESCRIPTION
Hi,

The extension available in the gnome store does not work with the lattest version of gnome shell with their api change to declare the provider. **Here's a fix.**

(There is also a change in firefox api, your extension will only work with a local FIREFOX_BOOKMARK_ because nowadays the firefox automatic bookmark backup are no longer in json but compressed)

Regards,
Pascal 